### PR TITLE
Enable discord.py logger by default.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,15 @@ however, insignificant breaking changes do not guarantee a major version bump, s
 - Loading the blocked list with the `?blocked` command takes a long time when the list is large. ([PR #3242](https://github.com/kyb3r/modmail/pull/3242))
 - Reply not being forwarded from DM. (PR [#3239](https://github.com/modmail-dev/modmail/pull/3239))
 
-# [UNRELEASED]
-
 ### Added
 - New .env config option: `REGISTRY_PLUGINS_ONLY`, restricts to only allow adding registry plugins. ([PR #3247](https://github.com/modmail-dev/modmail/pull/3247))
 
 ### Changed
 - Repo moved to https://github.com/modmail-dev/modmail.
+- Discord.py internal logging is now enabled by default. ([PR #3216](https://github.com/modmail-dev/Modmail/pull/3216))
+
+### Internal
+- Renamed `Bot.log_file_name` to `Bot.log_file_path`. Log files are now created at `temp/logs/modmail.log`. ([PR #3216](https://github.com/modmail-dev/Modmail/pull/3216))
 
 # v4.0.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,13 @@ however, insignificant breaking changes do not guarantee a major version bump, s
 - Reply not being forwarded from DM. (PR [#3239](https://github.com/modmail-dev/modmail/pull/3239))
 
 ### Added
-- New .env config option: `REGISTRY_PLUGINS_ONLY`, restricts to only allow adding registry plugins. ([PR #3247](https://github.com/modmail-dev/modmail/pull/3247))
 - `?log key <key>` to retrieve the log link and view a preview using a log key. ([PR #3196](https://github.com/modmail-dev/Modmail/pull/3196))
+- `REGISTRY_PLUGINS_ONLY`, environment variable, when set, restricts to only allow adding registry plugins. ([PR #3247](https://github.com/modmail-dev/modmail/pull/3247))
+- `DISCORD_LOG_LEVEL` environment variable to set the log level of discord.py. ([PR #3216](https://github.com/modmail-dev/Modmail/pull/3216))
 
 ### Changed
-- Guild icons in embed footers and author urls now have a fixed size of 128. ([PR #3261](https://github.com/modmail-dev/modmail/pull/3261))
 - Repo moved to https://github.com/modmail-dev/modmail.
+- Guild icons in embed footers and author urls now have a fixed size of 128. ([PR #3261](https://github.com/modmail-dev/modmail/pull/3261))
 - Discord.py internal logging is now enabled by default. ([PR #3216](https://github.com/modmail-dev/Modmail/pull/3216))
 
 ### Internal

--- a/bot.py
+++ b/bot.py
@@ -83,8 +83,11 @@ class ModmailBot(commands.Bot):
 
         self.threads = ThreadManager(self)
 
-        self.log_file_name = os.path.join(temp_dir, f"{self.token.split('.')[0]}.log")
-        configure_logging(self, temp_dir)
+        log_dir = os.path.join(temp_dir, "logs")
+        if not os.path.exists(log_dir):
+            os.mkdir(log_dir)
+        self.log_file_path = os.path.join(log_dir, "modmail.log")
+        configure_logging(self)
 
         self.plugin_db = PluginDatabaseClient(self)  # Deprecated
         self.startup()

--- a/cogs/utility.py
+++ b/cogs/utility.py
@@ -401,13 +401,7 @@ class Utility(commands.Cog):
     async def debug(self, ctx):
         """Shows the recent application logs of the bot."""
 
-        log_file_name = self.bot.token.split(".")[0]
-
-        with open(
-            os.path.join(os.path.dirname(os.path.abspath(__file__)), f"../temp/{log_file_name}.log"),
-            "r+",
-            encoding="utf-8",
-        ) as f:
+        with open(self.bot.log_file_path, "r+", encoding="utf-8") as f:
             logs = f.read().strip()
 
         if not logs:
@@ -455,12 +449,8 @@ class Utility(commands.Cog):
         """Posts application-logs to Hastebin."""
 
         haste_url = os.environ.get("HASTE_URL", "https://hastebin.cc")
-        log_file_name = self.bot.token.split(".")[0]
 
-        with open(
-            os.path.join(os.path.dirname(os.path.abspath(__file__)), f"../temp/{log_file_name}.log"),
-            "rb+",
-        ) as f:
+        with open(self.bot.log_file_path, "rb+") as f:
             logs = BytesIO(f.read().strip())
 
         try:
@@ -491,12 +481,7 @@ class Utility(commands.Cog):
     async def debug_clear(self, ctx):
         """Clears the locally cached logs."""
 
-        log_file_name = self.bot.token.split(".")[0]
-
-        with open(
-            os.path.join(os.path.dirname(os.path.abspath(__file__)), f"../temp/{log_file_name}.log"),
-            "w",
-        ):
+        with open(self.bot.log_file_path, "w"):
             pass
         await ctx.send(
             embed=discord.Embed(color=self.bot.main_color, description="Cached logs are now cleared.")

--- a/cogs/utility.py
+++ b/cogs/utility.py
@@ -427,7 +427,7 @@ class Utility(commands.Cog):
                     msg = "```Haskell\n"
             msg += line
             if len(msg) + 3 > 2000:
-                msg = msg[:1993] + "[...]```"
+                msg = msg[:1992] + "[...]```"
                 messages.append(msg)
                 msg = "```Haskell\n"
 

--- a/core/config.py
+++ b/core/config.py
@@ -178,6 +178,7 @@ class ConfigManager:
         "disable_updates": False,
         # Logging
         "log_level": "INFO",
+        "discord_log_level": "INFO",
         # data collection
         "data_collection": True,
     }

--- a/core/config_help.json
+++ b/core/config_help.json
@@ -1129,6 +1129,15 @@
       "This configuration can only to be set through `.env` file or environment (config) variables."
     ]
   },
+  "discord_log_level": {
+    "default": "INFO",
+    "description": "The `discord.py` library logging level for logging to stdout.",
+    "examples": [
+    ],
+    "notes": [
+      "This configuration can only to be set through `.env` file or environment (config) variables."
+    ]
+  },
   "enable_plugins": {
     "default": "Yes",
     "description": "Whether plugins should be enabled and loaded into Modmail.",


### PR DESCRIPTION
Refer to #3213.

- This will log discord.py library logs to `sys.stdout` by default.
- Defaults to `INFO` level.
- If the ~~`LOG_DISCORD`~~ `DISCORD_LOG_LEVEL` env config variable is set to `DEBUG`, the `DEBUG` level logs will be logged into a file i.e. `discord.log` separately while still logging the `INFO` level to `sys.stdout`.
- ~~Reorder imports and move logger stuff to top to properly initialize `colorama` and set text color to loggers. Otherwise the `discord.py` logger text would be in white. *This is kinda un-pythonic (type-checker will not like this). Proper way would be creating a new file for logger classes and stuff, and do early import of that file in `bot.py` to initialize those. I saw the implementation in [Red-DiscordBot](https://github.com/Cog-Creators/Red-DiscordBot) if I remember correctly. Let me know if this should be reverted.*~~