### PR TITLE
Fix replies in dms not being sent

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -888,7 +888,7 @@ class ModmailBot(commands.Bot):
             return
         sent_emoji, blocked_emoji = await self.retrieve_emoji()
 
-        if message.type not in {discord.MessageType.default, discord.MessageType.reply}:
+        if message.type not in [discord.MessageType.default, discord.MessageType.reply]:
             return
 
         thread = await self.threads.find(recipient=message.author)

--- a/bot.py
+++ b/bot.py
@@ -888,7 +888,7 @@ class ModmailBot(commands.Bot):
             return
         sent_emoji, blocked_emoji = await self.retrieve_emoji()
 
-        if message.type != discord.MessageType.default:
+        if message.type not in {discord.MessageType.default, discord.MessageType.reply}:
             return
 
         thread = await self.threads.find(recipient=message.author)


### PR DESCRIPTION
In discord.py v2, a new message type [`discord.MessageType.reply`](https://discordpy.readthedocs.io/en/stable/api.html?highlight=messagetype#discord.MessageType.reply) was added so we have to check for that as well.

Fixes #3238