### PR TITLE
Add dm_channel_id field to log entry

### DIFF
--- a/core/clients.py
+++ b/core/clients.py
@@ -568,6 +568,8 @@ class MongoDBClient(ApiClient):
     async def create_log_entry(self, recipient: Member, channel: TextChannel, creator: Member) -> str:
         key = secrets.token_hex(6)
 
+        dm_channel = await recipient.create_dm()
+
         await self.logs.insert_one(
             {
                 "_id": key,
@@ -578,6 +580,7 @@ class MongoDBClient(ApiClient):
                 "channel_id": str(channel.id),
                 "guild_id": str(self.bot.guild_id),
                 "bot_id": str(self.bot.user.id),
+                "dm_channel_id": str(dm_channel.id),
                 "recipient": {
                     "id": str(recipient.id),
                     "name": recipient.name,


### PR DESCRIPTION
Adds a `dm_channel_id` field to the mongodb log entry document containing the id of the dm channel between the bot and the recipient. 

DM channel ids are random and we can't determine them with the information currently in the database. By adding this field, we'll enable features like giving users the link to a specific message, if, for instance, they wanted to report it to discord.