### PR TITLE
fix ping command returning an AttributeError

### DIFF
--- a/cogs/utility.py
+++ b/cogs/utility.py
@@ -670,7 +670,7 @@ class Utility(commands.Cog):
         """Pong! Returns your websocket latency."""
         embed = discord.Embed(
             title="Pong! Websocket Latency:",
-            description=f"{self.bot.ws.latency * 1000:.4f} ms",
+            description=f"{self.bot.latency * 1000:.4f} ms",
             color=self.bot.main_color,
         )
         return await ctx.send(embed=embed)


### PR DESCRIPTION
basically fixes this issue
```py
Traceback (most recent call last):
  File "/home/ubuntu/.local/share/virtualenvs/modmail-7dS7szwO/lib/python3.10/site-packages/discord/ext/commands/core.py", line 229, in wrapped
    ret = await coro(*args, **kwargs)
  File "/home/ubuntu/modmail/core/utils.py", line 558, in wrapper
    return await func(self, ctx, *args, **kwargs)
  File "/home/ubuntu/modmail/cogs/utility.py", line 617, in ping
    description=f"{self.bot.ws.latency * 1000:.4f} ms",
AttributeError: 'NoneType' object has no attribute 'latency'
```