### PR TITLE
Add config to manage how long logs are stored

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1736,8 +1736,7 @@ class ModmailBot(commands.Bot):
                         next_expiry = closed_at + log_expire_after
                         return await discord.utils.sleep_until(next_expiry)
 
-        for log in expired_logs:
-            await self.db.logs.delete_one({"_id": log["_id"]})
+        await self.db.logs.delete_many({"closed_at": {"$lte": str(expiration_datetime)}})
         logger.info(f"Deleted {len(expired_logs)} expired logs.")
 
         fetch = await self.db.logs.find().sort("closed_at", 1).limit(1).to_list(None)

--- a/bot.py
+++ b/bot.py
@@ -12,7 +12,7 @@ import struct
 import sys
 import platform
 import typing
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
 from subprocess import PIPE
 from types import SimpleNamespace
 
@@ -633,6 +633,7 @@ class ModmailBot(commands.Bot):
 
         self.post_metadata.start()
         self.autoupdate.start()
+        self.log_expiry.start()
         self._started = True
 
     async def convert_emoji(self, name: str) -> str:
@@ -657,7 +658,6 @@ class ModmailBot(commands.Bot):
         return self.get_user(id) or await self.fetch_user(id)
 
     async def retrieve_emoji(self) -> typing.Tuple[str, str]:
-
         sent_emoji = self.config["sent_emoji"]
         blocked_emoji = self.config["blocked_emoji"]
 
@@ -731,7 +731,6 @@ class ModmailBot(commands.Bot):
         if isinstance(author, discord.Member):
             for r in author.roles:
                 if str(r.id) in self.blocked_roles:
-
                     blocked_reason = self.blocked_roles.get(str(r.id)) or ""
 
                     try:
@@ -790,7 +789,6 @@ class ModmailBot(commands.Bot):
         channel: discord.TextChannel = None,
         send_message: bool = False,
     ) -> bool:
-
         member = self.guild.get_member(author.id)
         if member is None:
             # try to find in other guilds
@@ -1713,6 +1711,42 @@ class ModmailBot(commands.Bot):
             logger.warning("Autoupdates disabled.")
             self.autoupdate.cancel()
             return
+
+    @tasks.loop()
+    async def log_expiry(self):
+        log_expire_after = self.config.get("log_expiration")
+        if log_expire_after == isodate.Duration():
+            return self.log_expiry.stop()
+
+        now = datetime.utcnow()
+        expiration_datetime = now - log_expire_after
+        expired_logs = await self.db.logs.find({"closed_at": {"$lte": str(expiration_datetime)}}).to_list(
+            None
+        )
+
+        if not await self.db.logs.find_one():
+            return await discord.utils.sleep_until(now + timedelta(days=1))
+
+        if not expired_logs:
+            fetch = await self.db.logs.find().sort("closed_at", 1).limit(1).to_list(None)
+            if fetch:
+                for x in fetch:
+                    if x["closed_at"] > str(expiration_datetime):
+                        closed_at = datetime.strptime(x["closed_at"], "%Y-%m-%d %H:%M:%S.%f%z")
+                        next_expiry = closed_at + log_expire_after
+                        return await discord.utils.sleep_until(next_expiry)
+
+        for log in expired_logs:
+            await self.db.logs.delete_one({"_id": log["_id"]})
+        logger.info(f"Deleted {len(expired_logs)} expired logs.")
+
+        fetch = await self.db.logs.find().sort("closed_at", 1).limit(1).to_list(None)
+        if fetch:
+            for x in fetch:
+                if x["closed_at"] > str(expiration_datetime):
+                    closed_at = datetime.strptime(x["closed_at"], "%Y-%m-%d %H:%M:%S.%f%z")
+                    next_expiry = closed_at + log_expire_after
+                    return await discord.utils.sleep_until(next_expiry)
 
     def format_channel_name(self, author, exclude_channel=None, force_null=False):
         """Sanitises a username for use with text channel names

--- a/cogs/plugins.py
+++ b/cogs/plugins.py
@@ -265,7 +265,6 @@ class Plugins(commands.Cog):
             raise InvalidPluginError("Cannot load extension, plugin invalid.") from exc
 
     async def parse_user_input(self, ctx, plugin_name, check_version=False):
-
         if not self.bot.config["enable_plugins"]:
             embed = discord.Embed(
                 description="Plugins are disabled, enable them by setting `ENABLE_PLUGINS=true`",
@@ -380,7 +379,6 @@ class Plugins(commands.Cog):
         await self.bot.config.update()
 
         if self.bot.config.get("enable_plugins"):
-
             invalidate_caches()
 
             try:

--- a/cogs/utility.py
+++ b/cogs/utility.py
@@ -599,7 +599,6 @@ class Utility(commands.Cog):
         return await ctx.send(embed=embed)
 
     async def set_presence(self, *, status=None, activity_type=None, activity_message=None):
-
         if status is None:
             status = self.bot.config.get("status")
 

--- a/core/config.py
+++ b/core/config.py
@@ -21,7 +21,6 @@ load_dotenv()
 
 
 class ConfigManager:
-
     public_keys = {
         # activity
         "twitch_url": "https://www.twitch.tv/discordmodmail/",
@@ -37,6 +36,7 @@ class ConfigManager:
         "account_age": isodate.Duration(),
         "guild_age": isodate.Duration(),
         "thread_cooldown": isodate.Duration(),
+        "log_expiration": isodate.Duration(),
         "reply_without_command": False,
         "anon_reply_without_command": False,
         "plain_reply_without_command": False,
@@ -183,7 +183,7 @@ class ConfigManager:
 
     colors = {"mod_color", "recipient_color", "main_color", "error_color"}
 
-    time_deltas = {"account_age", "guild_age", "thread_auto_close", "thread_cooldown"}
+    time_deltas = {"account_age", "guild_age", "thread_auto_close", "thread_cooldown", "log_expiration"}
 
     booleans = {
         "use_user_id_channel_name",

--- a/core/config_help.json
+++ b/core/config_help.json
@@ -375,7 +375,7 @@
   },
   "log_expiration": {
     "default": "Never",
-    "description": "Specify the duration of how long the thread log will be kept in the log channel. After the duration has passed, the log will be deleted.",
+    "description": "The duration closed threads will be stored within the database before deletion. Logs that have been closed for longer than this duration will be deleted automatically.",
     "examples": [
       "`{prefix}config set thread_cooldown P12DT3H` (stands for 12 days and 3 hours in [ISO-8601 Duration Format](https://en.wikipedia.org/wiki/ISO_8601#Durations))",
       "`{prefix}config set thread_cooldown 3 days and 5 hours` (accepted readable time)"

--- a/core/config_help.json
+++ b/core/config_help.json
@@ -377,8 +377,8 @@
     "default": "Never",
     "description": "The duration closed threads will be stored within the database before deletion. Logs that have been closed for longer than this duration will be deleted automatically.",
     "examples": [
-      "`{prefix}config set thread_cooldown P12DT3H` (stands for 12 days and 3 hours in [ISO-8601 Duration Format](https://en.wikipedia.org/wiki/ISO_8601#Durations))",
-      "`{prefix}config set thread_cooldown 3 days and 5 hours` (accepted readable time)"
+      "`{prefix}config set log_expiration P12DT3H` (stands for 12 days and 3 hours in [ISO-8601 Duration Format](https://en.wikipedia.org/wiki/ISO_8601#Durations))",
+      "`{prefix}config set log_expiration 3 days and 5 hours` (accepted readable time)"
     ],
     "notes": [
       "To disable log expiration, do `{prefix}config del log_expiration`."

--- a/core/config_help.json
+++ b/core/config_help.json
@@ -373,6 +373,17 @@
       "To disable thread cooldown, do `{prefix}config del thread_cooldown`."
     ]
   },
+  "log_expiration": {
+    "default": "Never",
+    "description": "Specify the duration of how long the thread log will be kept in the log channel. After the duration has passed, the log will be deleted.",
+    "examples": [
+      "`{prefix}config set thread_cooldown P12DT3H` (stands for 12 days and 3 hours in [ISO-8601 Duration Format](https://en.wikipedia.org/wiki/ISO_8601#Durations))",
+      "`{prefix}config set thread_cooldown 3 days and 5 hours` (accepted readable time)"
+    ],
+    "notes": [
+      "To disable log expiration, do `{prefix}config del log_expiration`."
+    ]
+  },
   "thread_cancelled": {
     "default": "\"Cancelled\"",
     "description": "This is the message to display when a thread times out and creation is cancelled.",

--- a/core/models.py
+++ b/core/models.py
@@ -202,7 +202,6 @@ class SimilarCategoryConverter(commands.CategoryChannelConverter):
         try:
             return await super().convert(ctx, argument)
         except commands.ChannelNotFound:
-
             if guild:
                 categories = {c.name.casefold(): c for c in guild.categories}
             else:

--- a/core/thread.py
+++ b/core/thread.py
@@ -716,7 +716,6 @@ class Thread:
     async def find_linked_message_from_dm(
         self, message, either_direction=False, get_thread_channel=False
     ) -> typing.List[discord.Message]:
-
         joint_id = None
         if either_direction:
             joint_id = get_joint_id(message)
@@ -909,7 +908,6 @@ class Thread:
         persistent_note: bool = False,
         thread_creation: bool = False,
     ) -> None:
-
         if not note and from_mod:
             self.bot.loop.create_task(self._restart_close_timer())  # Start or restart thread auto close
 


### PR DESCRIPTION
Closes #2942 

This pr adds a config option called `log_expiration` which can be configured in the same way as `thread_cooldown` etc. 
According to the `closed_at` field this config option will delete logs which have passed the time specified in `log_expiration`. 

This will work retrospectively. 