### PR TITLE
Remove python 3.8 and windows/macos lint check.

### DIFF
--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -4,13 +4,12 @@ on: [push, pull_request]
 
 jobs:
   code-style:
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.9', '3.10']
 
-    name: Python ${{ matrix.python-version }} on ${{ matrix.os }}
+    name: Python ${{ matrix.python-version }} on ubuntu-latest
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
The additional checks are unnecessary, thus removed.