### PR TITLE
Set smaller size for guild icons urls on embed icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ however, insignificant breaking changes do not guarantee a major version bump, s
 - Loading the blocked list with the `?blocked` command takes a long time when the list is large. ([PR #3242](https://github.com/kyb3r/modmail/pull/3242))
 - Reply not being forwarded from DM. (PR [#3239](https://github.com/modmail-dev/modmail/pull/3239))
 
+### Changed
+- Guild icons in embed footers and author urls now have a fixed size of 128. ([PR #3261](https://github.com/modmail-dev/modmail/pull/3261))
+
 # v4.0.2
 
 ### Breaking

--- a/bot.py
+++ b/bot.py
@@ -90,7 +90,9 @@ class ModmailBot(commands.Bot):
         self.plugin_db = PluginDatabaseClient(self)  # Deprecated
         self.startup()
 
-    def get_guild_icon(self, guild: typing.Optional[discord.Guild], *, size: typing.Optional[int] = None) -> str:
+    def get_guild_icon(
+        self, guild: typing.Optional[discord.Guild], *, size: typing.Optional[int] = None
+    ) -> str:
         if guild is None:
             guild = self.guild
         if guild.icon is None:

--- a/bot.py
+++ b/bot.py
@@ -90,12 +90,14 @@ class ModmailBot(commands.Bot):
         self.plugin_db = PluginDatabaseClient(self)  # Deprecated
         self.startup()
 
-    def get_guild_icon(self, guild: typing.Optional[discord.Guild]) -> str:
+    def get_guild_icon(self, guild: typing.Optional[discord.Guild], *, size: typing.Optional[int] = None) -> str:
         if guild is None:
             guild = self.guild
         if guild.icon is None:
             return "https://cdn.discordapp.com/embed/avatars/0.png"
-        return guild.icon.url
+        if size is None:
+            return guild.icon.url
+        return guild.icon.with_size(size)
 
     def _resolve_snippet(self, name: str) -> typing.Optional[str]:
         """
@@ -912,7 +914,7 @@ class ModmailBot(commands.Bot):
                 )
                 embed.set_footer(
                     text=self.config["disabled_new_thread_footer"],
-                    icon_url=self.get_guild_icon(guild=message.guild),
+                    icon_url=self.get_guild_icon(guild=message.guild, size=128),
                 )
                 logger.info("A new thread was blocked from %s due to disabled Modmail.", message.author)
                 await self.add_reaction(message, blocked_emoji)
@@ -928,7 +930,7 @@ class ModmailBot(commands.Bot):
                 )
                 embed.set_footer(
                     text=self.config["disabled_current_thread_footer"],
-                    icon_url=self.get_guild_icon(guild=message.guild),
+                    icon_url=self.get_guild_icon(guild=message.guild, size=128),
                 )
                 logger.info("A message was blocked from %s due to disabled Modmail.", message.author)
                 await self.add_reaction(message, blocked_emoji)
@@ -1335,7 +1337,7 @@ class ModmailBot(commands.Bot):
             )
             embed.set_footer(
                 text=self.config["disabled_new_thread_footer"],
-                icon_url=self.get_guild_icon(guild=channel.guild),
+                icon_url=self.get_guild_icon(guild=channel.guild, size=128),
             )
             logger.info(
                 "A new thread using react to contact was blocked from %s due to disabled Modmail.",

--- a/bot.py
+++ b/bot.py
@@ -99,7 +99,7 @@ class ModmailBot(commands.Bot):
             return "https://cdn.discordapp.com/embed/avatars/0.png"
         if size is None:
             return guild.icon.url
-        return guild.icon.with_size(size)
+        return guild.icon.with_size(size).url
 
     def _resolve_snippet(self, name: str) -> typing.Optional[str]:
         """

--- a/cogs/modmail.py
+++ b/cogs/modmail.py
@@ -160,7 +160,7 @@ class Modmail(commands.Cog):
                 color=self.bot.error_color, description="You dont have any snippets at the moment."
             )
             embed.set_footer(text=f'Check "{self.bot.prefix}help snippet add" to add a snippet.')
-            embed.set_author(name="Snippets", icon_url=self.bot.get_guild_icon(guild=ctx.guild))
+            embed.set_author(name="Snippets", icon_url=self.bot.get_guild_icon(guild=ctx.guild, size=128))
             return await ctx.send(embed=embed)
 
         embeds = []
@@ -168,7 +168,7 @@ class Modmail(commands.Cog):
         for i, names in enumerate(zip_longest(*(iter(sorted(self.bot.snippets)),) * 15)):
             description = format_description(i, names)
             embed = discord.Embed(color=self.bot.main_color, description=description)
-            embed.set_author(name="Snippets", icon_url=self.bot.get_guild_icon(guild=ctx.guild))
+            embed.set_author(name="Snippets", icon_url=self.bot.get_guild_icon(guild=ctx.guild, size=128))
             embeds.append(embed)
 
         session = EmbedPaginatorSession(ctx, *embeds)
@@ -1031,7 +1031,7 @@ class Modmail(commands.Cog):
                 name = tag
             avatar_url = self.bot.config["anon_avatar_url"]
             if avatar_url is None:
-                avatar_url = self.bot.get_guild_icon(guild=ctx.guild)
+                avatar_url = self.bot.get_guild_icon(guild=ctx.guild, size=128)
             em.set_footer(text=name, icon_url=avatar_url)
 
             for u in users:
@@ -1120,7 +1120,7 @@ class Modmail(commands.Cog):
                 name = tag
             avatar_url = self.bot.config["anon_avatar_url"]
             if avatar_url is None:
-                avatar_url = self.bot.get_guild_icon(guild=ctx.guild)
+                avatar_url = self.bot.get_guild_icon(guild=ctx.guild, size=128)
             em.set_footer(text=name, icon_url=avatar_url)
 
             for u in users:

--- a/cogs/utility.py
+++ b/cogs/utility.py
@@ -1020,7 +1020,7 @@ class Utility(commands.Cog):
                 color=self.bot.error_color, description="You dont have any aliases at the moment."
             )
             embed.set_footer(text=f'Do "{self.bot.prefix}help alias" for more commands.')
-            embed.set_author(name="Aliases", icon_url=self.bot.get_guild_icon(guild=ctx.guild))
+            embed.set_author(name="Aliases", icon_url=self.bot.get_guild_icon(guild=ctx.guild, size=128))
             return await ctx.send(embed=embed)
 
         embeds = []
@@ -1028,7 +1028,7 @@ class Utility(commands.Cog):
         for i, names in enumerate(zip_longest(*(iter(sorted(self.bot.aliases)),) * 15)):
             description = utils.format_description(i, names)
             embed = discord.Embed(color=self.bot.main_color, description=description)
-            embed.set_author(name="Command Aliases", icon_url=self.bot.get_guild_icon(guild=ctx.guild))
+            embed.set_author(name="Command Aliases", icon_url=self.bot.get_guild_icon(guild=ctx.guild, size=128))
             embeds.append(embed)
 
         session = EmbedPaginatorSession(ctx, *embeds)
@@ -1612,7 +1612,7 @@ class Utility(commands.Cog):
                             )
                             embed = discord.Embed(color=self.bot.main_color, description=description)
                             embed.set_author(
-                                name="Permission Overrides", icon_url=self.bot.get_guild_icon(guild=ctx.guild)
+                                name="Permission Overrides", icon_url=self.bot.get_guild_icon(guild=ctx.guild, size=128)
                             )
                             embeds.append(embed)
 

--- a/cogs/utility.py
+++ b/cogs/utility.py
@@ -1028,7 +1028,9 @@ class Utility(commands.Cog):
         for i, names in enumerate(zip_longest(*(iter(sorted(self.bot.aliases)),) * 15)):
             description = utils.format_description(i, names)
             embed = discord.Embed(color=self.bot.main_color, description=description)
-            embed.set_author(name="Command Aliases", icon_url=self.bot.get_guild_icon(guild=ctx.guild, size=128))
+            embed.set_author(
+                name="Command Aliases", icon_url=self.bot.get_guild_icon(guild=ctx.guild, size=128)
+            )
             embeds.append(embed)
 
         session = EmbedPaginatorSession(ctx, *embeds)
@@ -1612,7 +1614,8 @@ class Utility(commands.Cog):
                             )
                             embed = discord.Embed(color=self.bot.main_color, description=description)
                             embed.set_author(
-                                name="Permission Overrides", icon_url=self.bot.get_guild_icon(guild=ctx.guild, size=128)
+                                name="Permission Overrides",
+                                icon_url=self.bot.get_guild_icon(guild=ctx.guild, size=128),
                             )
                             embeds.append(embed)
 

--- a/core/thread.py
+++ b/core/thread.py
@@ -228,7 +228,7 @@ class Thread:
             else:
                 footer = self.bot.config["thread_creation_footer"]
 
-            embed.set_footer(text=footer, icon_url=self.bot.get_guild_icon(guild=self.bot.modmail_guild))
+            embed.set_footer(text=footer, icon_url=self.bot.get_guild_icon(guild=self.bot.modmail_guild, size=128))
             embed.title = self.bot.config["thread_creation_title"]
 
             if creator is None or creator == recipient:
@@ -521,7 +521,7 @@ class Thread:
 
         embed.description = message
         footer = self.bot.config["thread_close_footer"]
-        embed.set_footer(text=footer, icon_url=self.bot.get_guild_icon(guild=self.bot.guild))
+        embed.set_footer(text=footer, icon_url=self.bot.get_guild_icon(guild=self.bot.guild, size=128))
 
         if not silent:
             for user in self.recipients:
@@ -957,7 +957,7 @@ class Thread:
                     name = tag
                 avatar_url = self.bot.config["anon_avatar_url"]
                 if avatar_url is None:
-                    avatar_url = self.bot.get_guild_icon(guild=self.bot.guild)
+                    avatar_url = self.bot.get_guild_icon(guild=self.bot.guild, size=128)
                 embed.set_author(
                     name=name,
                     icon_url=avatar_url,

--- a/core/thread.py
+++ b/core/thread.py
@@ -228,7 +228,9 @@ class Thread:
             else:
                 footer = self.bot.config["thread_creation_footer"]
 
-            embed.set_footer(text=footer, icon_url=self.bot.get_guild_icon(guild=self.bot.modmail_guild, size=128))
+            embed.set_footer(
+                text=footer, icon_url=self.bot.get_guild_icon(guild=self.bot.modmail_guild, size=128)
+            )
             embed.title = self.bot.config["thread_creation_title"]
 
             if creator is None or creator == recipient:


### PR DESCRIPTION
The guild icon is used in full size on embed footers or the author icon for some messages. This can cause lag on the mobile app if the icon is animated.

This PR introduces a new optional `size` argument to `get_guild_icon` and sets the size to 128 when it's used for embed footers or author icons (I chose a conservative value, 64 should render nicely even on higher DPI).