### PR TITLE
confirm_thread_creation Buttons instead of reactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ however, insignificant breaking changes do not guarantee a major version bump, s
 ### Breaking
 
 - Presence intent is now by-default OFF. You can turn it on by setting `ENABLE_PRESENCE_INTENT=true` in the environment variables.
+- Using Buttons instead of reactions in ´´confirm_thread_creation``.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ however, insignificant breaking changes do not guarantee a major version bump, s
 - Repo moved to https://github.com/modmail-dev/modmail.
 - Guild icons in embed footers and author urls now have a fixed size of 128. ([PR #3261](https://github.com/modmail-dev/modmail/pull/3261))
 - Discord.py internal logging is now enabled by default. ([PR #3216](https://github.com/modmail-dev/Modmail/pull/3216))
+- The confirm-thread-creation dialog now uses buttons instead of reactions. ([PR #3273](https://github.com/modmail-dev/Modmail/pull/3273))
 
 ### Internal
 - Renamed `Bot.log_file_name` to `Bot.log_file_path`. Log files are now created at `temp/logs/modmail.log`. ([PR #3216](https://github.com/modmail-dev/Modmail/pull/3216))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,6 @@ however, insignificant breaking changes do not guarantee a major version bump, s
 ### Breaking
 
 - Presence intent is now by-default OFF. You can turn it on by setting `ENABLE_PRESENCE_INTENT=true` in the environment variables.
-- Using Buttons instead of reactions in ´´confirm_thread_creation``.
 
 ### Fixed
 

--- a/core/config.py
+++ b/core/config.py
@@ -123,7 +123,7 @@ class ConfigManager:
         # confirm thread creation
         "confirm_thread_creation": False,
         "confirm_thread_creation_title": "Confirm thread creation",
-        "confirm_thread_response": "React to confirm thread creation which will directly contact the moderators",
+        "confirm_thread_response": "Click the button to confirm thread creation which will directly contact the moderators.",
         "confirm_thread_creation_accept": "\N{WHITE HEAVY CHECK MARK}",
         "confirm_thread_creation_deny": "\N{NO ENTRY SIGN}",
         # regex

--- a/core/config_help.json
+++ b/core/config_help.json
@@ -1014,10 +1014,10 @@
     ]
   },
   "confirm_thread_response": {
-    "default": "React to confirm thread creation which will directly contact the moderators",
+    "default": "Click the button to confirm thread creation which will directly contact the moderators.",
     "description": "Description for the embed message sent to users to confirm a thread creation",
     "examples":[
-      "`{prefix}config set confirm_thread_response React to confirm`"
+      "`{prefix}config set confirm_thread_response Click to confirm`"
     ],
     "notes": [
       "See also: `confirm_thread_creation`, `confirm_thread_creation_title`, `confirm_thread_creation_accept`, `confirm_thread_creation_deny`"

--- a/core/thread.py
+++ b/core/thread.py
@@ -1431,7 +1431,7 @@ class ThreadManager:
                 view=view
             )
             await view.wait()
-            if view.value == None:
+            if view.value is None:
                 thread.cancelled = True
                 self.bot.loop.create_task(
                     destination.send(
@@ -1443,7 +1443,7 @@ class ThreadManager:
                     )
                 )
                 await confirm.edit(view=None)
-            if view.value == False:
+            if view.value is False:
                 thread.cancelled = True
                 self.bot.loop.create_task(
                     destination.send(

--- a/core/thread.py
+++ b/core/thread.py
@@ -31,7 +31,7 @@ from core.utils import (
     get_joint_id,
     AcceptButton,
     DenyButton,
-    ConfirmThreadCreationView
+    ConfirmThreadCreationView,
 )
 
 logger = getLogger(__name__)
@@ -1426,9 +1426,9 @@ class ThreadManager:
                 embed=discord.Embed(
                     title=self.bot.config["confirm_thread_creation_title"],
                     description=self.bot.config["confirm_thread_response"],
-                    color=self.bot.main_color
+                    color=self.bot.main_color,
                 ),
-                view=view
+                view=view,
             )
             await view.wait()
             if view.value is None:

--- a/core/utils.py
+++ b/core/utils.py
@@ -41,7 +41,7 @@ __all__ = [
     "extract_block_timestamp",
     "AcceptButton",
     "DenyButton",
-    "ConfirmThreadCreationView"
+    "ConfirmThreadCreationView",
 ]
 
 
@@ -563,29 +563,26 @@ def extract_block_timestamp(reason, id_):
 
     return end_time, after
 
+
 class AcceptButton(discord.ui.Button):
     def __init__(self, emoji):
-        super().__init__(
-            style=discord.ButtonStyle.gray,
-            emoji=emoji
-        )
-    
+        super().__init__(style=discord.ButtonStyle.gray, emoji=emoji)
+
     async def callback(self, interaction: discord.Interaction):
         self.view.value = True
         await interaction.response.edit_message(view=None)
         self.view.stop()
 
+
 class DenyButton(discord.ui.Button):
     def __init__(self, emoji):
-        super().__init__(
-            style=discord.ButtonStyle.gray,
-            emoji=emoji
-        )
-    
+        super().__init__(style=discord.ButtonStyle.gray, emoji=emoji)
+
     async def callback(self, interaction: discord.Interaction):
         self.view.value = False
         await interaction.response.edit_message(view=None)
         self.view.stop()
+
 
 class ConfirmThreadCreationView(discord.ui.View):
     def __init__(self):

--- a/core/utils.py
+++ b/core/utils.py
@@ -39,6 +39,9 @@ __all__ = [
     "get_top_role",
     "get_joint_id",
     "extract_block_timestamp",
+    "AcceptButton",
+    "DenyButton",
+    "ConfirmThreadCreationView"
 ]
 
 
@@ -559,3 +562,32 @@ def extract_block_timestamp(reason, id_):
             raise
 
     return end_time, after
+
+class AcceptButton(discord.ui.Button):
+    def __init__(self, emoji):
+        super().__init__(
+            style=discord.ButtonStyle.gray,
+            emoji=emoji
+        )
+    
+    async def callback(self, interaction: discord.Interaction):
+        self.view.value = True
+        await interaction.response.edit_message(view=None)
+        self.view.stop()
+
+class DenyButton(discord.ui.Button):
+    def __init__(self, emoji):
+        super().__init__(
+            style=discord.ButtonStyle.gray,
+            emoji=emoji
+        )
+    
+    async def callback(self, interaction: discord.Interaction):
+        self.view.value = False
+        await interaction.response.edit_message(view=None)
+        self.view.stop()
+
+class ConfirmThreadCreationView(discord.ui.View):
+    def __init__(self):
+        super().__init__(timeout=20)
+        self.value = None

--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -35,11 +35,11 @@
         "icon_url": "https://i.imgur.com/qtE7AH8.png",
         "thumbnail_url": "https://i.imgur.com/qtE7AH8.png"
     },
-	"reminder": {
+    "reminder": {
         "repository": "martinbndr/kyb3r-modmail-plugins",
         "branch": "master",
         "description": "Let´s you create reminders.",
-        "bot_version": "4.0.0",          
+        "bot_version": "4.0.0",
         "title": "Reminder",
         "icon_url": "https://raw.githubusercontent.com/martinbndr/kyb3r-modmail-plugins/master/reminder/logo.png",
         "thumbnail_url": "https://raw.githubusercontent.com/martinbndr/kyb3r-modmail-plugins/master/reminder/logo.png"
@@ -75,43 +75,43 @@
         "repository": "fourjr/modmail-plugins",
         "branch": "v4",
         "description": "Allows managing server emotes via ?emoji",
-        "bot_version": "4.0.0",        
+        "bot_version": "4.0.0",
         "title": "Emote Manager",
         "icon_url": "https://i.imgur.com/Mo60CdK.png",
         "thumbnail_url": "https://i.imgur.com/Mo60CdK.png"
     },
-     "gen-log": {
+    "gen-log": {
         "repository": "fourjr/modmail-plugins",
         "branch": "v4",
         "description": "Outputs a text log of a thread in a specified channel",
-        "bot_version": "4.0.0",         
+        "bot_version": "4.0.0",
         "title": "Log Generator",
         "icon_url": "https://i.imgur.com/Mo60CdK.png",
         "thumbnail_url": "https://i.imgur.com/Mo60CdK.png"
     },
-     "media-logger": {
+    "media-logger": {
         "repository": "fourjr/modmail-plugins",
         "branch": "v4",
         "description": "Re-posts detected media from all visible channels into a specified logging channel",
-        "bot_version": "4.0.0",         
+        "bot_version": "4.0.0",
         "title": "Media Logger",
         "icon_url": "https://i.imgur.com/Mo60CdK.png",
         "thumbnail_url": "https://i.imgur.com/Mo60CdK.png"
     },
-      "report": {
+    "report": {
         "repository": "fourjr/modmail-plugins",
         "branch": "v4",
         "description": "Specify an emoji to react with on messages. Generates a 'report' in specified logging channel upon react.",
-        "bot_version": "4.0.0",          
+        "bot_version": "4.0.0",
         "title": "Report",
         "icon_url": "https://i.imgur.com/Mo60CdK.png",
         "thumbnail_url": "https://i.imgur.com/Mo60CdK.png"
     },
-      "top-supporters": {
+    "top-supporters": {
         "repository": "fourjr/modmail-plugins",
         "branch": "v4",
         "description": "Gathers and prints the top supporters of handling threads.",
-        "bot_version": "4.0.0",          
+        "bot_version": "4.0.0",
         "title": "Top Supporters",
         "icon_url": "https://i.imgur.com/Mo60CdK.png",
         "thumbnail_url": "https://i.imgur.com/Mo60CdK.png"

--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -35,6 +35,15 @@
         "icon_url": "https://i.imgur.com/qtE7AH8.png",
         "thumbnail_url": "https://i.imgur.com/qtE7AH8.png"
     },
+	"reminder": {
+        "repository": "martinbndr/kyb3r-modmail-plugins",
+        "branch": "master",
+        "description": "Let´s you create reminders.",
+        "bot_version": "4.0.0",          
+        "title": "Reminder",
+        "icon_url": "https://raw.githubusercontent.com/martinbndr/kyb3r-modmail-plugins/master/reminder/logo.png",
+        "thumbnail_url": "https://raw.githubusercontent.com/martinbndr/kyb3r-modmail-plugins/master/reminder/logo.png"
+    },
     "welcomer": {
         "repository": "fourjr/modmail-plugins",
         "branch": "v4",


### PR DESCRIPTION
This pr replaces reactions with buttons for the confirm_thread_creation feature.
Buttons should be more userfriendly and stable for this feature. Changes tested, should work 100%