### PR TITLE
[Fix] disable new command not updating db config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ however, insignificant breaking changes do not guarantee a major version bump, s
 - Guild icons in embed footers and author urls now have a fixed size of 128. ([PR #3261](https://github.com/modmail-dev/modmail/pull/3261))
 - Discord.py internal logging is now enabled by default. ([PR #3216](https://github.com/modmail-dev/Modmail/pull/3216))
 - The confirm-thread-creation dialog now uses buttons instead of reactions. ([PR #3273](https://github.com/modmail-dev/Modmail/pull/3273))
+- `?disable all` no longer overrides `?disable new`. ([PR #3278](https://github.com/modmail-dev/Modmail/pull/3278))
 
 ### Internal
 - Renamed `Bot.log_file_name` to `Bot.log_file_path`. Log files are now created at `temp/logs/modmail.log`. ([PR #3216](https://github.com/modmail-dev/Modmail/pull/3216))

--- a/cogs/modmail.py
+++ b/cogs/modmail.py
@@ -2138,7 +2138,7 @@ class Modmail(commands.Cog):
             description="Modmail will not create any new threads.",
             color=self.bot.main_color,
         )
-        if self.bot.config["dm_disabled"] < DMDisabled.NEW_THREADS:
+        if self.bot.config["dm_disabled"] != DMDisabled.NEW_THREADS:
             self.bot.config["dm_disabled"] = DMDisabled.NEW_THREADS
             await self.bot.config.update()
 


### PR DESCRIPTION
Steps to reproduce:
1. ?disable all
2. ?disable new

After switching from all threads disabled to only new ones ``dm_disabled`` does not get updated to 1 (only new threads disabled).
![image](https://user-images.githubusercontent.com/55140357/231158901-ed7876f3-1f4a-40d8-93d3-dc8af68018cc.png)

Changes have been applied and tested.