### PR TITLE
Remove Heroku Reference from Debug Command

### DIFF
--- a/cogs/utility.py
+++ b/cogs/utility.py
@@ -416,7 +416,7 @@ class Utility(commands.Cog):
                 title="Debug Logs:",
                 description="You don't have any logs at the moment.",
             )
-            embed.set_footer(text="Go to Heroku to see your logs.")
+            embed.set_footer(text="Go to your console to see your logs.")
             return await ctx.send(embed=embed)
 
         messages = []


### PR DESCRIPTION
Very few users are still using Heroku for hosting their instance of Modmail. As such, this comment could cause confusion in regard to where to find their logs. So, changing it to a general term, such as console, remedies this issue, and doesn't specifically target any one hosting method.