### PR TITLE
Add `generalinfo` plugin to `plugins/registry.json`.

### DIFF
--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -26,6 +26,15 @@
         "icon_url": "https://raw.githubusercontent.com/martinbndr/kyb3r-modmail-plugins/master/autoreact/logo.png",
         "thumbnail_url": "https://raw.githubusercontent.com/martinbndr/kyb3r-modmail-plugins/master/autoreact/logo.png"
     },
+    "generalinfo": {
+        "repository": "Jerrie-Aries/modmail-plugins",
+        "branch": "master",
+        "description": "Get general information about bot, guild member, Discord user, server and many more.",
+        "bot_version": "4.0.0",
+        "title": "General Info",
+        "icon_url": "https://github.com/Jerrie-Aries.png",
+        "thumbnail_url": "https://raw.githubusercontent.com/Jerrie-Aries/extras/master/icons/info.jpg"
+    },
     "giveaway": {
         "repository": "Jerrie-Aries/modmail-plugins",
         "branch": "master",


### PR DESCRIPTION
This PR adds `generalinfo` plugin to `plugins/registry.json`.

__**Commands:**__
`botinfo` - Modmail bot info.
`charinfo` - Information about a number of characters. (*Credits to [Rapptz/RoboDanny](https://github.com/Rapptz/RoboDanny/blob/rewrite/cogs/meta.py)*)
`roleinfo` - Information of a role specified.
`serverinfo` - Information of the server.
`useravatar` - Avatar (profile picture) of a member.
`userinfo` - Information of a guild member or Discord user.
`rolemembers` - List of members in a role specified.
`allroles` - List of roles on the server.
`guildemojis` - List of custom emojis in the server with their IDs.

Those commands and/or their functionalities may be extended later.