### PR TITLE
Fix Docker file permission issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ FROM base
 # Copy the entire venv.
 COPY --from=builder --chown=modmail:modmail /opt/modmail/.venv /opt/modmail/.venv
 
-# copy repository files
+# Copy repository files.
 WORKDIR /opt/modmail
 USER modmail:modmail
 COPY --chown=modmail:modmail . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,38 +1,38 @@
-FROM python:3.11-alpine as base
+FROM python:3.11-slim-bookworm as base
 
-RUN apk add --no-cache \
-    # cairosvg dependencies
-    cairo-dev cairo cairo-tools \
-    # pillow dependencies
-    jpeg-dev zlib-dev \
-    && adduser -D -h /home/modmail -g 'Modmail' modmail
-
-ENV VIRTUAL_ENV=/home/modmail/.venv
-ENV PATH="$VIRTUAL_ENV/bin:$PATH"
-
-WORKDIR /home/modmail
+RUN apt-get update &&  \
+    apt-get install --no-install-recommends -y \
+    # Install CairoSVG dependencies.
+    libcairo2 && \
+    # Cleanup APT.
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    # Create a non-root user.
+    useradd --create-home -d /opt/modmail modmail
 
 FROM base as builder
 
-RUN apk add build-base libffi-dev
+COPY requirements.txt .
 
-RUN python -m venv $VIRTUAL_ENV
+RUN pip install --root-user-action=ignore --no-cache-dir --upgrade pip wheel && \
+    python -m venv /opt/modmail/.venv && \
+    . /opt/modmail/.venv/bin/activate && \
+    pip install --no-cache-dir --upgrade -r requirements.txt
 
-COPY --chown=modmail:modmail requirements.txt .
-RUN pip install --upgrade pip setuptools && \
-    pip install -r requirements.txt
+FROM base
 
-FROM base as runtime
-
-# copy the entire venv
-COPY --from=builder --chown=modmail:modmail $VIRTUAL_ENV $VIRTUAL_ENV
+# Copy the entire venv.
+COPY --from=builder --chown=modmail:modmail /opt/modmail/.venv /opt/modmail/.venv
 
 # copy repository files
+WORKDIR /opt/modmail
+USER modmail:modmail
 COPY --chown=modmail:modmail . .
 
-# this disables the internal auto-update
-ENV USING_DOCKER yes
-
-USER modmail
+# This sets some Python runtime variables and disables the internal auto-update.
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PATH=/opt/modmail/.venv/bin:$PATH \
+    USING_DOCKER=yes
 
 CMD ["python", "bot.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update &&  \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
     # Create a non-root user.
-    useradd --create-home -d /opt/modmail modmail
+    useradd --shell /usr/sbin/nologin --create-home -d /opt/modmail modmail
 
 FROM base as builder
 


### PR DESCRIPTION
This PR fixes the permission issue (#3319) by installing the Python dependencies as a non-root user.

It also changes the base python image to alpine version since it's smaller in size.

This reduced image size from 1.07GB ~> 250MB. Tested with locally-built image on Docker Desktop 4.25.2 (129061)

~~Ignore the messy commits I'm too lazy to squash them~~