### PR TITLE
Improve parity between plugin add and plugin remove #3260

### DIFF
--- a/cogs/plugins.py
+++ b/cogs/plugins.py
@@ -428,7 +428,7 @@ class Plugins(commands.Cog):
             )
         return await msg.edit(embed=embed)
 
-    @plugins.command(name="remove", aliases=["del", "delete"])
+    @plugins.command(name="remove", aliases=["del", "delete", "uninstall", "unload"])
     @checks.has_permissions(PermissionLevel.OWNER)
     async def plugins_remove(self, ctx, *, plugin_name: str):
         """


### PR DESCRIPTION
Resolves #3260 

Added `uninstall` and `unload` as aliases to the `plugin remove` command