### PR TITLE
Added a Polls plugin to registry.json

### DIFF
--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -133,5 +133,14 @@
         "title": "Rename",
         "icon_url": "https://i.imgur.com/A1auJ95.png",
         "thumbnail_url": "https://i.imgur.com/A1auJ95.png"
+    },
+    "polls": {
+        "repository": "noinoiexists/modmail-plugins",
+        "branch": "main",
+        "description": "Customizable polling system to create polls with role restrictions, multiple options, and automatic result announcement.",
+        "bot_version": "4.0.0",
+        "title": "Polls",
+        "icon_url": "https://i.imgur.com/Mo60CdK.png",
+        "thumbnail_url": "https://i.imgur.com/jmoLr6X.jpeg"
     }
 }

--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -138,7 +138,7 @@
         "repository": "noinoiexists/modmail-plugins",
         "branch": "main",
         "description": "Customizable polling system to create polls with role restrictions, multiple options, and automatic result announcement.",
-        "bot_version": "4.0.0",
+        "bot_version": "4.1.1",
         "title": "Polls",
         "icon_url": "https://i.imgur.com/Mo60CdK.png",
         "thumbnail_url": "https://i.imgur.com/jmoLr6X.jpeg"


### PR DESCRIPTION
This plugin is used to create Polls in a Discord server. It has the following features:
- Create polls with up to 10 options.
- Role-based restrictions on who can vote.
- Automatic result announcements with voting breakdown.
- Easy-to-use modal interface for poll creation.