### PR TITLE
Fix wrong guild icon

### DIFF
--- a/core/thread.py
+++ b/core/thread.py
@@ -233,7 +233,7 @@ class Thread:
                 footer = self.bot.config["thread_creation_footer"]
 
             embed.set_footer(
-                text=footer, icon_url=self.bot.get_guild_icon(guild=self.bot.modmail_guild, size=128)
+                text=footer, icon_url=self.bot.get_guild_icon(guild=self.bot.guild, size=128)
             )
             embed.title = self.bot.config["thread_creation_title"]
 


### PR DESCRIPTION
This PR fixes displaying the wrong guild icon in the thread_creation_response embed.
When servers having a seperate server setup, the guild icon from the main guild should be displayed instead of the inbox guild.