### PR TITLE
Fix: Image url regex in thread send method

### DIFF
--- a/core/thread.py
+++ b/core/thread.py
@@ -1001,7 +1001,7 @@ class Thread:
                 attachments.append(attachment)
 
         image_urls = re.findall(
-            r"http[s]?:\/\/(?:[a-zA-Z]|[0-9]|[$\-_@.&+]|[!*(),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+",
+            r"http[s]?:\/\/(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*(),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+",
             message.content,
         )
 


### PR DESCRIPTION
Revert image URL regex change in thread.py. The current regex only matches the protocol and domain, and no longer validates full image URLs.